### PR TITLE
Move Coca-Cola to order 40 in sorting layer

### DIFF
--- a/The Quest for the Game/Assets/Scenes/SvennzHouse.unity
+++ b/The Quest for the Game/Assets/Scenes/SvennzHouse.unity
@@ -2440,7 +2440,7 @@ SpriteRenderer:
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: -457038567
   m_SortingLayer: 4
-  m_SortingOrder: 4
+  m_SortingOrder: 40
   m_Sprite: {fileID: 21300000, guid: 099ea3a27f624be408754e28c9a943ac, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0


### PR DESCRIPTION
Forgot to bump Coca-Cola sorting layer order when changing interval from 1 to 10 earlier - thanks @Victor-733 for noticing.